### PR TITLE
Remove use of #[may_dangle]

### DIFF
--- a/examples/may_dangle.rs
+++ b/examples/may_dangle.rs
@@ -1,0 +1,17 @@
+extern crate rayon_hash;
+
+fn main() {
+    // The standard collections can have type parameters with
+    // the same lifetime as the collection itself:
+    let (x, mut set) = (0, std::collections::HashSet::new());
+    set.insert(&x);
+
+    // FIXME: We can't do this without `#[may_dangle]` on `Drop for RawTable`:
+    // let (x, mut set) = (0, rayon_hash::HashSet::new());
+    // set.insert(&x);
+
+    // Instead, we our type parameters must strictly outlive the collection.
+    let x = 0;
+    let mut set = rayon_hash::HashSet::new();
+    set.insert(&x);
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,6 @@
 #![feature(alloc)]
 #![feature(allocator_api)]
-#![feature(dropck_eyepatch)]
 #![cfg_attr(rayon_hash_unstable, feature(fused))]
-#![feature(generic_param_attrs)]
 #![cfg_attr(rayon_hash_unstable, feature(placement_new_protocol))]
 #![feature(shared)]
 #![feature(unique)]

--- a/src/std_hash/table.rs
+++ b/src/std_hash/table.rs
@@ -1171,7 +1171,8 @@ impl<K: Clone, V: Clone> Clone for RawTable<K, V> {
     }
 }
 
-unsafe impl<#[may_dangle] K, #[may_dangle] V> Drop for RawTable<K, V> {
+// unsafe impl<#[may_dangle] K, #[may_dangle] V> Drop for RawTable<K, V> {
+impl<K, V> Drop for RawTable<K, V> {
     fn drop(&mut self) {
         if self.capacity() == 0 {
             return;


### PR DESCRIPTION
Removing this lets us drop two unstable features.  I've included an
example file which shows what functionality we lose with this.

Fixes #2.