### PR TITLE
Allocate RawTable through a Vec

### DIFF
--- a/src/heap.rs
+++ b/src/heap.rs
@@ -1,0 +1,44 @@
+//! Crudely approximating the `alloc::heap` API
+
+use std::mem;
+
+fn capacity<T>(size: usize) -> usize {
+    let t_size = mem::size_of::<T>();
+    assert!(t_size > 0);
+    size.checked_add(t_size - 1).unwrap() / t_size
+}
+
+
+fn alloc1<T>(size: usize) -> *mut u8 {
+    let cap = capacity::<T>(size);
+    let mut v = Vec::<T>::with_capacity(cap);
+    let p = v.as_mut_ptr();
+    mem::forget(v);
+    p as *mut u8
+}
+
+pub fn alloc<A, B>(size: usize, align: usize) -> *mut u8 {
+    if mem::align_of::<A>() == align {
+        alloc1::<A>(size)
+    } else if mem::align_of::<B>() == align {
+        alloc1::<B>(size)
+    } else {
+        panic!("invalid alignment: {}", align);
+    }
+}
+
+
+unsafe fn dealloc1<T>(p: *mut u8, size: usize) {
+    let cap = capacity::<T>(size);
+    Vec::<T>::from_raw_parts(p as *mut T, 0, cap);
+}
+
+pub unsafe fn dealloc<A, B>(p: *mut u8, size: usize, align: usize) {
+    if mem::align_of::<A>() == align {
+        dealloc1::<A>(p, size)
+    } else if mem::align_of::<B>() == align {
+        dealloc1::<B>(p, size)
+    } else {
+        panic!("invalid alignment: {}", align);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,3 @@
-#![feature(alloc)]
-#![feature(allocator_api)]
 #![cfg_attr(rayon_hash_unstable, feature(fused))]
 #![cfg_attr(rayon_hash_unstable, feature(placement_new_protocol))]
 #![feature(shared)]
@@ -8,7 +6,6 @@
 #![cfg_attr(all(rayon_hash_unstable, test), feature(placement_in_syntax))]
 #![cfg_attr(test, feature(test))]
 
-extern crate alloc;
 extern crate rayon;
 
 #[cfg(test)] extern crate rand;
@@ -22,6 +19,8 @@ use std::marker;
 use std::mem;
 use std::ops;
 use std::ptr;
+
+mod heap;
 
 #[cfg(all(rayon_hash_unstable, test))] use std::panic;
 #[cfg(test)] use std::cell;

--- a/src/std_hash/table.rs
+++ b/src/std_hash/table.rs
@@ -8,7 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use alloc::heap::{Heap, Alloc, Layout};
+// use alloc::heap::{Heap, Alloc, Layout};
+use heap;
 
 use cmp;
 use hash::{BuildHasher, Hash, Hasher};
@@ -788,8 +789,9 @@ impl<K, V> RawTable<K, V> {
                     .expect("capacity overflow"),
                 "capacity overflow");
 
-        let buffer = Heap.alloc(Layout::from_size_align(size, alignment).unwrap())
-            .unwrap_or_else(|e| Heap.oom(e));
+        // let buffer = Heap.alloc(Layout::from_size_align(size, alignment).unwrap())
+        //     .unwrap_or_else(|e| Heap.oom(e));
+        let buffer = heap::alloc::<HashUint, (K, V)>(size, alignment);
 
         let hashes = buffer as *mut HashUint;
 
@@ -1200,8 +1202,9 @@ impl<K, V> Drop for RawTable<K, V> {
         debug_assert!(!oflo, "should be impossible");
 
         unsafe {
-            Heap.dealloc(self.hashes.ptr() as *mut u8,
-                         Layout::from_size_align(size, align).unwrap());
+            // Heap.dealloc(self.hashes.ptr() as *mut u8,
+            //              Layout::from_size_align(size, align).unwrap());
+            heap::dealloc::<HashUint, (K, V)>(self.hashes.ptr() as *mut u8, size, align);
             // Remember how everything was allocated out of one buffer
             // during initialization? We only need one call to free here.
         }


### PR DESCRIPTION
The `RawTable` allocation matches the greater alignment of either
`HashUint` or `(K, V)`.  This adds an `alloc` functions that's generic
on two types, so we can match alignment to one of them and allocate that
kind of `Vec<_>` with an appropriate capacity.

Fixes #3.