### PR TITLE
Enable building with stable Rust!

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ sudo: false
 matrix:
   fast_finish: true
   include:
+    - rust: 1.21.0
+    - rust: stable
+    - rust: beta
     - rust: nightly
 
     - rust: nightly

--- a/COPYRIGHT
+++ b/COPYRIGHT
@@ -1,0 +1,19 @@
+Short version for non-lawyers:
+
+The Rust Project is dual-licensed under Apache 2.0 and MIT
+terms.
+
+
+Longer version:
+
+Copyrights in the Rust project are retained by their contributors. No
+copyright assignment is required to contribute to the Rust project.
+
+Some files include explicit copyright notices and/or license notices.
+For full authorship information, see AUTHORS.txt and the version control
+history.
+
+Except as otherwise noted (below and/or in individual files), Rust is
+licensed under the Apache License, Version 2.0 <LICENSE-APACHE> or
+<http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+<LICENSE-MIT> or <http://opensource.org/licenses/MIT>, at your option.

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ can't access internal fields, it has to collect to an intermediate vector to be
 split into parallel jobs.  With the custom types in `rayon-hash`, we can
 instead read the raw hash table directly, for much better performance.
 
+This crate currently requires `rustc 1.21.0` or greater.
+
 ## Known limitations
 
 Some compromises have been made to let this work on stable Rust, compared to

--- a/README.md
+++ b/README.md
@@ -8,6 +8,22 @@ can't access internal fields, it has to collect to an intermediate vector to be
 split into parallel jobs.  With the custom types in `rayon-hash`, we can
 instead read the raw hash table directly, for much better performance.
 
+## Known limitations
+
+Some compromises have been made to let this work on stable Rust, compared to
+the standard types that may use unstable features.  There are examples included
+which demonstrate the differences.
+
+- [`examples/may_dangle.rs`](examples/may_dangle.rs): Since we don't use the
+  unstable `#[may_dangle]` attributes, the type parameters of `HashMap<K, V>`
+  and `HashSet<T>` must strictly outlive the container itself.
+
+- [`examples/nonzero.rs`](examples/nonzero.rs): We use duplicated `Unique` and
+  `Shared` pointer types, containing a duplicate `NonZero` that's not marked
+  `#[lang = "non_zero"]`.  This means the compiler won't apply the intended
+  enum optimizations, so wrappers like `Option<HashMap<_,_>>` end up larger to
+  store the enum discriminant separately.
+
 ## Unstable features
 
 Some of the features copied from `std` would be guarded with `#[unstable]`

--- a/benches/std_hash.rs
+++ b/benches/std_hash.rs
@@ -8,16 +8,16 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![cfg(test)]
+#![feature(test)]
 
+extern crate rayon_hash;
 extern crate test;
 
-use self::test::Bencher;
+use rayon_hash::HashMap;
+use test::Bencher;
 
 #[bench]
 fn new_drop(b: &mut Bencher) {
-    use super::map::HashMap;
-
     b.iter(|| {
         let m: HashMap<i32, i32> = HashMap::new();
         assert_eq!(m.len(), 0);
@@ -26,8 +26,6 @@ fn new_drop(b: &mut Bencher) {
 
 #[bench]
 fn new_insert_drop(b: &mut Bencher) {
-    use super::map::HashMap;
-
     b.iter(|| {
         let mut m = HashMap::new();
         m.insert(0, 0);
@@ -37,8 +35,6 @@ fn new_insert_drop(b: &mut Bencher) {
 
 #[bench]
 fn grow_by_insertion(b: &mut Bencher) {
-    use super::map::HashMap;
-
     let mut m = HashMap::new();
 
     for i in 1..1001 {
@@ -55,8 +51,6 @@ fn grow_by_insertion(b: &mut Bencher) {
 
 #[bench]
 fn find_existing(b: &mut Bencher) {
-    use super::map::HashMap;
-
     let mut m = HashMap::new();
 
     for i in 1..1001 {
@@ -72,8 +66,6 @@ fn find_existing(b: &mut Bencher) {
 
 #[bench]
 fn find_nonexisting(b: &mut Bencher) {
-    use super::map::HashMap;
-
     let mut m = HashMap::new();
 
     for i in 1..1001 {
@@ -89,8 +81,6 @@ fn find_nonexisting(b: &mut Bencher) {
 
 #[bench]
 fn hashmap_as_queue(b: &mut Bencher) {
-    use super::map::HashMap;
-
     let mut m = HashMap::new();
 
     for i in 1..1001 {
@@ -108,8 +98,6 @@ fn hashmap_as_queue(b: &mut Bencher) {
 
 #[bench]
 fn get_remove_insert(b: &mut Bencher) {
-    use super::map::HashMap;
-
     let mut m = HashMap::new();
 
     for i in 1..1001 {

--- a/examples/nonzero.rs
+++ b/examples/nonzero.rs
@@ -1,0 +1,17 @@
+extern crate rayon_hash;
+
+use std::mem::size_of;
+
+fn main() {
+    // With a proper `NonZero` implementation, `Option` takes no extra space.
+    println!("size_of::<std::collections::HashSet<i32, i32>>() -> {}",
+              size_of::<std::collections::HashSet<i32, i32>>());
+    println!("size_of::<Option<std::collections::HashSet<i32, i32>>>() -> {}",
+              size_of::<Option<std::collections::HashSet<i32, i32>>>());
+
+    // With stable rust, our `NonZero` doesn't do anything.
+    println!("size_of::<rayon_hash::HashSet<i32, i32>>() -> {}",
+              size_of::<rayon_hash::HashSet<i32, i32>>());
+    println!("size_of::<Option<rayon_hash::HashSet<i32, i32>>>() -> {}",
+              size_of::<Option<rayon_hash::HashSet<i32, i32>>>());
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,6 @@
 #![cfg_attr(rayon_hash_unstable, feature(placement_new_protocol))]
 
 #![cfg_attr(all(rayon_hash_unstable, test), feature(placement_in_syntax))]
-#![cfg_attr(test, feature(test))]
 
 extern crate rayon;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,10 @@
 #![cfg_attr(rayon_hash_unstable, feature(fused))]
 #![cfg_attr(rayon_hash_unstable, feature(placement_new_protocol))]
-#![feature(shared)]
-#![feature(unique)]
+#![feature(coerce_unsized)]
+#![feature(const_fn)]
+#![feature(i128_type)]
+#![feature(optin_builtin_traits)]
+#![feature(unsize)]
 
 #![cfg_attr(all(rayon_hash_unstable, test), feature(placement_in_syntax))]
 #![cfg_attr(test, feature(test))]
@@ -11,6 +14,8 @@ extern crate rayon;
 #[cfg(test)] extern crate rand;
 
 mod heap;
+mod nonzero;
+mod ptr;
 
 #[cfg(all(rayon_hash_unstable, test))] use std::panic;
 #[cfg(test)] use std::cell;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,16 +10,6 @@ extern crate rayon;
 
 #[cfg(test)] extern crate rand;
 
-use std::borrow;
-use std::cmp;
-use std::fmt;
-use std::hash;
-use std::iter;
-use std::marker;
-use std::mem;
-use std::ops;
-use std::ptr;
-
 mod heap;
 
 #[cfg(all(rayon_hash_unstable, test))] use std::panic;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,10 +1,5 @@
 #![cfg_attr(rayon_hash_unstable, feature(fused))]
 #![cfg_attr(rayon_hash_unstable, feature(placement_new_protocol))]
-#![feature(coerce_unsized)]
-#![feature(const_fn)]
-#![feature(i128_type)]
-#![feature(optin_builtin_traits)]
-#![feature(unsize)]
 
 #![cfg_attr(all(rayon_hash_unstable, test), feature(placement_in_syntax))]
 #![cfg_attr(test, feature(test))]

--- a/src/nonzero.rs
+++ b/src/nonzero.rs
@@ -10,83 +10,25 @@
 
 //! Exposes the NonZero lang item which provides optimization hints.
 //! (but not really, because now we're in a non-core stable crate...)
-// #![unstable(feature = "nonzero",
-//             reason = "needs an RFC to flesh out the design",
-//             issue = "27730")]
-
-use std::ops::CoerceUnsized;
 
 /// Unsafe trait to indicate what types are usable with the NonZero struct
-pub unsafe trait Zeroable {
-    /// Whether this value is zero
-    fn is_zero(&self) -> bool;
-}
+pub unsafe trait Zeroable {}
 
-macro_rules! impl_zeroable_for_pointer_types {
-    ( $( $Ptr: ty )+ ) => {
-        $(
-            /// For fat pointers to be considered "zero", only the "data" part needs to be null.
-            unsafe impl<T: ?Sized> Zeroable for $Ptr {
-                #[inline]
-                fn is_zero(&self) -> bool {
-                    // Cast because `is_null` is only available on thin pointers
-                    (*self as *mut u8).is_null()
-                }
-            }
-        )+
-    }
-}
-
-macro_rules! impl_zeroable_for_integer_types {
-    ( $( $Int: ty )+ ) => {
-        $(
-            unsafe impl Zeroable for $Int {
-                #[inline]
-                fn is_zero(&self) -> bool {
-                    *self == 0
-                }
-            }
-        )+
-    }
-}
-
-impl_zeroable_for_pointer_types! {
-    *const T
-    *mut T
-}
-
-impl_zeroable_for_integer_types! {
-    usize u8 u16 u32 u64 u128
-    isize i8 i16 i32 i64 i128
-}
+unsafe impl<T: ?Sized> Zeroable for *const T {}
+unsafe impl<T: ?Sized> Zeroable for *mut T {}
 
 /// A wrapper type for raw pointers and integers that will never be
 /// NULL or 0 that might allow certain optimizations.
 /// (but not really, because now we're in a non-core stable crate...)
-// #[lang = "non_zero"]
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Debug, Hash)]
 pub struct NonZero<T: Zeroable>(T);
 
 impl<T: Zeroable> NonZero<T> {
     /// Creates an instance of NonZero with the provided value.
     /// You must indeed ensure that the value is actually "non-zero".
-    // #[unstable(feature = "nonzero",
-    //            reason = "needs an RFC to flesh out the design",
-    //            issue = "27730")]
-    // #[rustc_const_unstable(feature = "const_nonzero_new")]
     #[inline]
-    pub const unsafe fn new_unchecked(inner: T) -> Self {
+    pub unsafe fn new_unchecked(inner: T) -> Self {
         NonZero(inner)
-    }
-
-    /// Creates an instance of NonZero with the provided value.
-    #[inline]
-    pub fn new(inner: T) -> Option<Self> {
-        if inner.is_zero() {
-            None
-        } else {
-            Some(NonZero(inner))
-        }
     }
 
     /// Gets the inner value.
@@ -94,8 +36,6 @@ impl<T: Zeroable> NonZero<T> {
         self.0
     }
 }
-
-impl<T: Zeroable+CoerceUnsized<U>, U: Zeroable> CoerceUnsized<NonZero<U>> for NonZero<T> {}
 
 impl<'a, T: ?Sized> From<&'a mut T> for NonZero<*mut T> {
     fn from(reference: &'a mut T) -> Self {

--- a/src/nonzero.rs
+++ b/src/nonzero.rs
@@ -1,0 +1,117 @@
+// Copyright 2012-2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//! Exposes the NonZero lang item which provides optimization hints.
+//! (but not really, because now we're in a non-core stable crate...)
+// #![unstable(feature = "nonzero",
+//             reason = "needs an RFC to flesh out the design",
+//             issue = "27730")]
+
+use std::ops::CoerceUnsized;
+
+/// Unsafe trait to indicate what types are usable with the NonZero struct
+pub unsafe trait Zeroable {
+    /// Whether this value is zero
+    fn is_zero(&self) -> bool;
+}
+
+macro_rules! impl_zeroable_for_pointer_types {
+    ( $( $Ptr: ty )+ ) => {
+        $(
+            /// For fat pointers to be considered "zero", only the "data" part needs to be null.
+            unsafe impl<T: ?Sized> Zeroable for $Ptr {
+                #[inline]
+                fn is_zero(&self) -> bool {
+                    // Cast because `is_null` is only available on thin pointers
+                    (*self as *mut u8).is_null()
+                }
+            }
+        )+
+    }
+}
+
+macro_rules! impl_zeroable_for_integer_types {
+    ( $( $Int: ty )+ ) => {
+        $(
+            unsafe impl Zeroable for $Int {
+                #[inline]
+                fn is_zero(&self) -> bool {
+                    *self == 0
+                }
+            }
+        )+
+    }
+}
+
+impl_zeroable_for_pointer_types! {
+    *const T
+    *mut T
+}
+
+impl_zeroable_for_integer_types! {
+    usize u8 u16 u32 u64 u128
+    isize i8 i16 i32 i64 i128
+}
+
+/// A wrapper type for raw pointers and integers that will never be
+/// NULL or 0 that might allow certain optimizations.
+/// (but not really, because now we're in a non-core stable crate...)
+// #[lang = "non_zero"]
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Debug, Hash)]
+pub struct NonZero<T: Zeroable>(T);
+
+impl<T: Zeroable> NonZero<T> {
+    /// Creates an instance of NonZero with the provided value.
+    /// You must indeed ensure that the value is actually "non-zero".
+    // #[unstable(feature = "nonzero",
+    //            reason = "needs an RFC to flesh out the design",
+    //            issue = "27730")]
+    // #[rustc_const_unstable(feature = "const_nonzero_new")]
+    #[inline]
+    pub const unsafe fn new_unchecked(inner: T) -> Self {
+        NonZero(inner)
+    }
+
+    /// Creates an instance of NonZero with the provided value.
+    #[inline]
+    pub fn new(inner: T) -> Option<Self> {
+        if inner.is_zero() {
+            None
+        } else {
+            Some(NonZero(inner))
+        }
+    }
+
+    /// Gets the inner value.
+    pub fn get(self) -> T {
+        self.0
+    }
+}
+
+impl<T: Zeroable+CoerceUnsized<U>, U: Zeroable> CoerceUnsized<NonZero<U>> for NonZero<T> {}
+
+impl<'a, T: ?Sized> From<&'a mut T> for NonZero<*mut T> {
+    fn from(reference: &'a mut T) -> Self {
+        NonZero(reference)
+    }
+}
+
+impl<'a, T: ?Sized> From<&'a mut T> for NonZero<*const T> {
+    fn from(reference: &'a mut T) -> Self {
+        let ptr: *mut T = reference;
+        NonZero(ptr)
+    }
+}
+
+impl<'a, T: ?Sized> From<&'a T> for NonZero<*const T> {
+    fn from(reference: &'a T) -> Self {
+        NonZero(reference)
+    }
+}

--- a/src/ptr.rs
+++ b/src/ptr.rs
@@ -8,10 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::ops::CoerceUnsized;
-use std::fmt;
-use std::marker::{PhantomData, Unsize};
-use std::mem;
+use std::marker::PhantomData;
 use nonzero::NonZero;
 
 /// A wrapper around a raw non-null `*mut T` that indicates that the possessor
@@ -35,8 +32,6 @@ use nonzero::NonZero;
 /// Unlike `*mut T`, `Unique<T>` is covariant over `T`. This should always be correct
 /// for any type which upholds Unique's aliasing requirements.
 #[allow(missing_debug_implementations)]
-// #[unstable(feature = "unique", reason = "needs an RFC to flesh out design",
-//            issue = "27730")]
 pub struct Unique<T: ?Sized> {
     pointer: NonZero<*const T>,
     // NOTE: this marker has no consequences for variance, but is necessary
@@ -51,105 +46,38 @@ pub struct Unique<T: ?Sized> {
 /// reference is unaliased. Note that this aliasing invariant is
 /// unenforced by the type system; the abstraction using the
 /// `Unique` must enforce it.
-// #[unstable(feature = "unique", issue = "27730")]
 unsafe impl<T: Send + ?Sized> Send for Unique<T> { }
 
 /// `Unique` pointers are `Sync` if `T` is `Sync` because the data they
 /// reference is unaliased. Note that this aliasing invariant is
 /// unenforced by the type system; the abstraction using the
 /// `Unique` must enforce it.
-// #[unstable(feature = "unique", issue = "27730")]
 unsafe impl<T: Sync + ?Sized> Sync for Unique<T> { }
 
-// #[unstable(feature = "unique", issue = "27730")]
-impl<T: Sized> Unique<T> {
-    /// Creates a new `Unique` that is dangling, but well-aligned.
-    ///
-    /// This is useful for initializing types which lazily allocate, like
-    /// `Vec::new` does.
-    pub fn empty() -> Self {
-        unsafe {
-            let ptr = mem::align_of::<T>() as *mut T;
-            Unique::new_unchecked(ptr)
-        }
-    }
-}
-
-// #[unstable(feature = "unique", issue = "27730")]
 impl<T: ?Sized> Unique<T> {
     /// Creates a new `Unique`.
     ///
     /// # Safety
     ///
     /// `ptr` must be non-null.
-    // #[unstable(feature = "unique", issue = "27730")]
-    // #[rustc_const_unstable(feature = "const_unique_new")]
-    pub const unsafe fn new_unchecked(ptr: *mut T) -> Self {
+    pub unsafe fn new_unchecked(ptr: *mut T) -> Self {
         Unique { pointer: NonZero::new_unchecked(ptr), _marker: PhantomData }
-    }
-
-    /// Creates a new `Unique` if `ptr` is non-null.
-    pub fn new(ptr: *mut T) -> Option<Self> {
-        NonZero::new(ptr as *const T).map(|nz| Unique { pointer: nz, _marker: PhantomData })
     }
 
     /// Acquires the underlying `*mut` pointer.
     pub fn as_ptr(self) -> *mut T {
         self.pointer.get() as *mut T
     }
-
-    /// Dereferences the content.
-    ///
-    /// The resulting lifetime is bound to self so this behaves "as if"
-    /// it were actually an instance of T that is getting borrowed. If a longer
-    /// (unbound) lifetime is needed, use `&*my_ptr.ptr()`.
-    pub unsafe fn as_ref(&self) -> &T {
-        &*self.as_ptr()
-    }
-
-    /// Mutably dereferences the content.
-    ///
-    /// The resulting lifetime is bound to self so this behaves "as if"
-    /// it were actually an instance of T that is getting borrowed. If a longer
-    /// (unbound) lifetime is needed, use `&mut *my_ptr.ptr()`.
-    pub unsafe fn as_mut(&mut self) -> &mut T {
-        &mut *self.as_ptr()
-    }
 }
 
-// #[unstable(feature = "unique", issue = "27730")]
 impl<T: ?Sized> Clone for Unique<T> {
     fn clone(&self) -> Self {
         *self
     }
 }
 
-// #[unstable(feature = "unique", issue = "27730")]
 impl<T: ?Sized> Copy for Unique<T> { }
 
-// #[unstable(feature = "unique", issue = "27730")]
-impl<T: ?Sized, U: ?Sized> CoerceUnsized<Unique<U>> for Unique<T> where T: Unsize<U> { }
-
-// #[unstable(feature = "unique", issue = "27730")]
-impl<T: ?Sized> fmt::Pointer for Unique<T> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        fmt::Pointer::fmt(&self.as_ptr(), f)
-    }
-}
-
-// #[unstable(feature = "unique", issue = "27730")]
-impl<'a, T: ?Sized> From<&'a mut T> for Unique<T> {
-    fn from(reference: &'a mut T) -> Self {
-        Unique { pointer: NonZero::from(reference), _marker: PhantomData }
-    }
-}
-
-// #[unstable(feature = "unique", issue = "27730")]
-impl<'a, T: ?Sized> From<&'a T> for Unique<T> {
-    fn from(reference: &'a T) -> Self {
-        Unique { pointer: NonZero::from(reference), _marker: PhantomData }
-    }
-}
 
 /// A wrapper around a raw `*mut T` that indicates that the possessor
 /// of this wrapper has shared ownership of the referent. Useful for
@@ -174,8 +102,6 @@ impl<'a, T: ?Sized> From<&'a T> for Unique<T> {
 /// because they provide a public API that follows the normal shared XOR mutable
 /// rules of Rust.
 #[allow(missing_debug_implementations)]
-// #[unstable(feature = "shared", reason = "needs an RFC to flesh out design",
-//            issue = "27730")]
 pub struct Shared<T: ?Sized> {
     pointer: NonZero<*const T>,
     // NOTE: this marker has no consequences for variance, but is necessary
@@ -186,60 +112,13 @@ pub struct Shared<T: ?Sized> {
     _marker: PhantomData<T>,
 }
 
-/// `Shared` pointers are not `Send` because the data they reference may be aliased.
-// NB: This impl is unnecessary, but should provide better error messages.
-// #[unstable(feature = "shared", issue = "27730")]
-impl<T: ?Sized> !Send for Shared<T> { }
+// `Shared` pointers are not `Send` because the data they reference may be aliased.
+// `Shared` pointers are not `Sync` because the data they reference may be aliased.
 
-/// `Shared` pointers are not `Sync` because the data they reference may be aliased.
-// NB: This impl is unnecessary, but should provide better error messages.
-// #[unstable(feature = "shared", issue = "27730")]
-impl<T: ?Sized> !Sync for Shared<T> { }
-
-// #[unstable(feature = "shared", issue = "27730")]
-impl<T: Sized> Shared<T> {
-    /// Creates a new `Shared` that is dangling, but well-aligned.
-    ///
-    /// This is useful for initializing types which lazily allocate, like
-    /// `Vec::new` does.
-    pub fn empty() -> Self {
-        unsafe {
-            let ptr = mem::align_of::<T>() as *mut T;
-            Shared::new_unchecked(ptr)
-        }
-    }
-}
-
-// #[unstable(feature = "shared", issue = "27730")]
 impl<T: ?Sized> Shared<T> {
-    /// Creates a new `Shared`.
-    ///
-    /// # Safety
-    ///
-    /// `ptr` must be non-null.
-    // #[unstable(feature = "shared", issue = "27730")]
-    // #[rustc_const_unstable(feature = "const_shared_new")]
-    pub const unsafe fn new_unchecked(ptr: *mut T) -> Self {
-        Shared { pointer: NonZero::new_unchecked(ptr), _marker: PhantomData }
-    }
-
-    /// Creates a new `Shared` if `ptr` is non-null.
-    pub fn new(ptr: *mut T) -> Option<Self> {
-        NonZero::new(ptr as *const T).map(|nz| Shared { pointer: nz, _marker: PhantomData })
-    }
-
     /// Acquires the underlying `*mut` pointer.
     pub fn as_ptr(self) -> *mut T {
         self.pointer.get() as *mut T
-    }
-
-    /// Dereferences the content.
-    ///
-    /// The resulting lifetime is bound to self so this behaves "as if"
-    /// it were actually an instance of T that is getting borrowed. If a longer
-    /// (unbound) lifetime is needed, use `&*my_ptr.ptr()`.
-    pub unsafe fn as_ref(&self) -> &T {
-        &*self.as_ptr()
     }
 
     /// Mutably dereferences the content.
@@ -250,52 +129,18 @@ impl<T: ?Sized> Shared<T> {
     pub unsafe fn as_mut(&mut self) -> &mut T {
         &mut *self.as_ptr()
     }
-
-    /// Acquires the underlying pointer as a `*mut` pointer.
-    // #[rustc_deprecated(since = "1.19", reason = "renamed to `as_ptr` for ergonomics/consistency")]
-    // #[unstable(feature = "shared", issue = "27730")]
-    pub unsafe fn as_mut_ptr(&self) -> *mut T {
-        self.as_ptr()
-    }
 }
 
-// #[unstable(feature = "shared", issue = "27730")]
 impl<T: ?Sized> Clone for Shared<T> {
     fn clone(&self) -> Self {
         *self
     }
 }
 
-// #[unstable(feature = "shared", issue = "27730")]
 impl<T: ?Sized> Copy for Shared<T> { }
 
-// #[unstable(feature = "shared", issue = "27730")]
-impl<T: ?Sized, U: ?Sized> CoerceUnsized<Shared<U>> for Shared<T> where T: Unsize<U> { }
-
-// #[unstable(feature = "shared", issue = "27730")]
-impl<T: ?Sized> fmt::Pointer for Shared<T> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        fmt::Pointer::fmt(&self.as_ptr(), f)
-    }
-}
-
-// #[unstable(feature = "shared", issue = "27730")]
-impl<T: ?Sized> From<Unique<T>> for Shared<T> {
-    fn from(unique: Unique<T>) -> Self {
-        Shared { pointer: unique.pointer, _marker: PhantomData }
-    }
-}
-
-// #[unstable(feature = "shared", issue = "27730")]
 impl<'a, T: ?Sized> From<&'a mut T> for Shared<T> {
     fn from(reference: &'a mut T) -> Self {
-        Shared { pointer: NonZero::from(reference), _marker: PhantomData }
-    }
-}
-
-// #[unstable(feature = "shared", issue = "27730")]
-impl<'a, T: ?Sized> From<&'a T> for Shared<T> {
-    fn from(reference: &'a T) -> Self {
         Shared { pointer: NonZero::from(reference), _marker: PhantomData }
     }
 }

--- a/src/ptr.rs
+++ b/src/ptr.rs
@@ -1,0 +1,301 @@
+// Copyright 2012-2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use std::ops::CoerceUnsized;
+use std::fmt;
+use std::marker::{PhantomData, Unsize};
+use std::mem;
+use nonzero::NonZero;
+
+/// A wrapper around a raw non-null `*mut T` that indicates that the possessor
+/// of this wrapper owns the referent. Useful for building abstractions like
+/// `Box<T>`, `Vec<T>`, `String`, and `HashMap<K, V>`.
+///
+/// Unlike `*mut T`, `Unique<T>` behaves "as if" it were an instance of `T`.
+/// It implements `Send`/`Sync` if `T` is `Send`/`Sync`. It also implies
+/// the kind of strong aliasing guarantees an instance of `T` can expect:
+/// the referent of the pointer should not be modified without a unique path to
+/// its owning Unique.
+///
+/// If you're uncertain of whether it's correct to use `Unique` for your purposes,
+/// consider using `Shared`, which has weaker semantics.
+///
+/// Unlike `*mut T`, the pointer must always be non-null, even if the pointer
+/// is never dereferenced. This is so that enums may use this forbidden value
+/// as a discriminant -- `Option<Unique<T>>` has the same size as `Unique<T>`.
+/// However the pointer may still dangle if it isn't dereferenced.
+///
+/// Unlike `*mut T`, `Unique<T>` is covariant over `T`. This should always be correct
+/// for any type which upholds Unique's aliasing requirements.
+#[allow(missing_debug_implementations)]
+// #[unstable(feature = "unique", reason = "needs an RFC to flesh out design",
+//            issue = "27730")]
+pub struct Unique<T: ?Sized> {
+    pointer: NonZero<*const T>,
+    // NOTE: this marker has no consequences for variance, but is necessary
+    // for dropck to understand that we logically own a `T`.
+    //
+    // For details, see:
+    // https://github.com/rust-lang/rfcs/blob/master/text/0769-sound-generic-drop.md#phantom-data
+    _marker: PhantomData<T>,
+}
+
+/// `Unique` pointers are `Send` if `T` is `Send` because the data they
+/// reference is unaliased. Note that this aliasing invariant is
+/// unenforced by the type system; the abstraction using the
+/// `Unique` must enforce it.
+// #[unstable(feature = "unique", issue = "27730")]
+unsafe impl<T: Send + ?Sized> Send for Unique<T> { }
+
+/// `Unique` pointers are `Sync` if `T` is `Sync` because the data they
+/// reference is unaliased. Note that this aliasing invariant is
+/// unenforced by the type system; the abstraction using the
+/// `Unique` must enforce it.
+// #[unstable(feature = "unique", issue = "27730")]
+unsafe impl<T: Sync + ?Sized> Sync for Unique<T> { }
+
+// #[unstable(feature = "unique", issue = "27730")]
+impl<T: Sized> Unique<T> {
+    /// Creates a new `Unique` that is dangling, but well-aligned.
+    ///
+    /// This is useful for initializing types which lazily allocate, like
+    /// `Vec::new` does.
+    pub fn empty() -> Self {
+        unsafe {
+            let ptr = mem::align_of::<T>() as *mut T;
+            Unique::new_unchecked(ptr)
+        }
+    }
+}
+
+// #[unstable(feature = "unique", issue = "27730")]
+impl<T: ?Sized> Unique<T> {
+    /// Creates a new `Unique`.
+    ///
+    /// # Safety
+    ///
+    /// `ptr` must be non-null.
+    // #[unstable(feature = "unique", issue = "27730")]
+    // #[rustc_const_unstable(feature = "const_unique_new")]
+    pub const unsafe fn new_unchecked(ptr: *mut T) -> Self {
+        Unique { pointer: NonZero::new_unchecked(ptr), _marker: PhantomData }
+    }
+
+    /// Creates a new `Unique` if `ptr` is non-null.
+    pub fn new(ptr: *mut T) -> Option<Self> {
+        NonZero::new(ptr as *const T).map(|nz| Unique { pointer: nz, _marker: PhantomData })
+    }
+
+    /// Acquires the underlying `*mut` pointer.
+    pub fn as_ptr(self) -> *mut T {
+        self.pointer.get() as *mut T
+    }
+
+    /// Dereferences the content.
+    ///
+    /// The resulting lifetime is bound to self so this behaves "as if"
+    /// it were actually an instance of T that is getting borrowed. If a longer
+    /// (unbound) lifetime is needed, use `&*my_ptr.ptr()`.
+    pub unsafe fn as_ref(&self) -> &T {
+        &*self.as_ptr()
+    }
+
+    /// Mutably dereferences the content.
+    ///
+    /// The resulting lifetime is bound to self so this behaves "as if"
+    /// it were actually an instance of T that is getting borrowed. If a longer
+    /// (unbound) lifetime is needed, use `&mut *my_ptr.ptr()`.
+    pub unsafe fn as_mut(&mut self) -> &mut T {
+        &mut *self.as_ptr()
+    }
+}
+
+// #[unstable(feature = "unique", issue = "27730")]
+impl<T: ?Sized> Clone for Unique<T> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+// #[unstable(feature = "unique", issue = "27730")]
+impl<T: ?Sized> Copy for Unique<T> { }
+
+// #[unstable(feature = "unique", issue = "27730")]
+impl<T: ?Sized, U: ?Sized> CoerceUnsized<Unique<U>> for Unique<T> where T: Unsize<U> { }
+
+// #[unstable(feature = "unique", issue = "27730")]
+impl<T: ?Sized> fmt::Pointer for Unique<T> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Pointer::fmt(&self.as_ptr(), f)
+    }
+}
+
+// #[unstable(feature = "unique", issue = "27730")]
+impl<'a, T: ?Sized> From<&'a mut T> for Unique<T> {
+    fn from(reference: &'a mut T) -> Self {
+        Unique { pointer: NonZero::from(reference), _marker: PhantomData }
+    }
+}
+
+// #[unstable(feature = "unique", issue = "27730")]
+impl<'a, T: ?Sized> From<&'a T> for Unique<T> {
+    fn from(reference: &'a T) -> Self {
+        Unique { pointer: NonZero::from(reference), _marker: PhantomData }
+    }
+}
+
+/// A wrapper around a raw `*mut T` that indicates that the possessor
+/// of this wrapper has shared ownership of the referent. Useful for
+/// building abstractions like `Rc<T>`, `Arc<T>`, or doubly-linked lists, which
+/// internally use aliased raw pointers to manage the memory that they own.
+///
+/// This is similar to `Unique`, except that it doesn't make any aliasing
+/// guarantees, and doesn't derive Send and Sync. Note that unlike `&T`,
+/// Shared has no special mutability requirements. Shared may mutate data
+/// aliased by other Shared pointers. More precise rules require Rust to
+/// develop an actual aliasing model.
+///
+/// Unlike `*mut T`, the pointer must always be non-null, even if the pointer
+/// is never dereferenced. This is so that enums may use this forbidden value
+/// as a discriminant -- `Option<Shared<T>>` has the same size as `Shared<T>`.
+/// However the pointer may still dangle if it isn't dereferenced.
+///
+/// Unlike `*mut T`, `Shared<T>` is covariant over `T`. If this is incorrect
+/// for your use case, you should include some PhantomData in your type to
+/// provide invariance, such as `PhantomData<Cell<T>>` or `PhantomData<&'a mut T>`.
+/// Usually this won't be necessary; covariance is correct for Rc, Arc, and LinkedList
+/// because they provide a public API that follows the normal shared XOR mutable
+/// rules of Rust.
+#[allow(missing_debug_implementations)]
+// #[unstable(feature = "shared", reason = "needs an RFC to flesh out design",
+//            issue = "27730")]
+pub struct Shared<T: ?Sized> {
+    pointer: NonZero<*const T>,
+    // NOTE: this marker has no consequences for variance, but is necessary
+    // for dropck to understand that we logically own a `T`.
+    //
+    // For details, see:
+    // https://github.com/rust-lang/rfcs/blob/master/text/0769-sound-generic-drop.md#phantom-data
+    _marker: PhantomData<T>,
+}
+
+/// `Shared` pointers are not `Send` because the data they reference may be aliased.
+// NB: This impl is unnecessary, but should provide better error messages.
+// #[unstable(feature = "shared", issue = "27730")]
+impl<T: ?Sized> !Send for Shared<T> { }
+
+/// `Shared` pointers are not `Sync` because the data they reference may be aliased.
+// NB: This impl is unnecessary, but should provide better error messages.
+// #[unstable(feature = "shared", issue = "27730")]
+impl<T: ?Sized> !Sync for Shared<T> { }
+
+// #[unstable(feature = "shared", issue = "27730")]
+impl<T: Sized> Shared<T> {
+    /// Creates a new `Shared` that is dangling, but well-aligned.
+    ///
+    /// This is useful for initializing types which lazily allocate, like
+    /// `Vec::new` does.
+    pub fn empty() -> Self {
+        unsafe {
+            let ptr = mem::align_of::<T>() as *mut T;
+            Shared::new_unchecked(ptr)
+        }
+    }
+}
+
+// #[unstable(feature = "shared", issue = "27730")]
+impl<T: ?Sized> Shared<T> {
+    /// Creates a new `Shared`.
+    ///
+    /// # Safety
+    ///
+    /// `ptr` must be non-null.
+    // #[unstable(feature = "shared", issue = "27730")]
+    // #[rustc_const_unstable(feature = "const_shared_new")]
+    pub const unsafe fn new_unchecked(ptr: *mut T) -> Self {
+        Shared { pointer: NonZero::new_unchecked(ptr), _marker: PhantomData }
+    }
+
+    /// Creates a new `Shared` if `ptr` is non-null.
+    pub fn new(ptr: *mut T) -> Option<Self> {
+        NonZero::new(ptr as *const T).map(|nz| Shared { pointer: nz, _marker: PhantomData })
+    }
+
+    /// Acquires the underlying `*mut` pointer.
+    pub fn as_ptr(self) -> *mut T {
+        self.pointer.get() as *mut T
+    }
+
+    /// Dereferences the content.
+    ///
+    /// The resulting lifetime is bound to self so this behaves "as if"
+    /// it were actually an instance of T that is getting borrowed. If a longer
+    /// (unbound) lifetime is needed, use `&*my_ptr.ptr()`.
+    pub unsafe fn as_ref(&self) -> &T {
+        &*self.as_ptr()
+    }
+
+    /// Mutably dereferences the content.
+    ///
+    /// The resulting lifetime is bound to self so this behaves "as if"
+    /// it were actually an instance of T that is getting borrowed. If a longer
+    /// (unbound) lifetime is needed, use `&mut *my_ptr.ptr_mut()`.
+    pub unsafe fn as_mut(&mut self) -> &mut T {
+        &mut *self.as_ptr()
+    }
+
+    /// Acquires the underlying pointer as a `*mut` pointer.
+    // #[rustc_deprecated(since = "1.19", reason = "renamed to `as_ptr` for ergonomics/consistency")]
+    // #[unstable(feature = "shared", issue = "27730")]
+    pub unsafe fn as_mut_ptr(&self) -> *mut T {
+        self.as_ptr()
+    }
+}
+
+// #[unstable(feature = "shared", issue = "27730")]
+impl<T: ?Sized> Clone for Shared<T> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+// #[unstable(feature = "shared", issue = "27730")]
+impl<T: ?Sized> Copy for Shared<T> { }
+
+// #[unstable(feature = "shared", issue = "27730")]
+impl<T: ?Sized, U: ?Sized> CoerceUnsized<Shared<U>> for Shared<T> where T: Unsize<U> { }
+
+// #[unstable(feature = "shared", issue = "27730")]
+impl<T: ?Sized> fmt::Pointer for Shared<T> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Pointer::fmt(&self.as_ptr(), f)
+    }
+}
+
+// #[unstable(feature = "shared", issue = "27730")]
+impl<T: ?Sized> From<Unique<T>> for Shared<T> {
+    fn from(unique: Unique<T>) -> Self {
+        Shared { pointer: unique.pointer, _marker: PhantomData }
+    }
+}
+
+// #[unstable(feature = "shared", issue = "27730")]
+impl<'a, T: ?Sized> From<&'a mut T> for Shared<T> {
+    fn from(reference: &'a mut T) -> Self {
+        Shared { pointer: NonZero::from(reference), _marker: PhantomData }
+    }
+}
+
+// #[unstable(feature = "shared", issue = "27730")]
+impl<'a, T: ?Sized> From<&'a T> for Shared<T> {
+    fn from(reference: &'a T) -> Self {
+        Shared { pointer: NonZero::from(reference), _marker: PhantomData }
+    }
+}

--- a/src/std_hash/map.rs
+++ b/src/std_hash/map.rs
@@ -11,16 +11,16 @@
 use self::Entry::*;
 use self::VacantEntryState::*;
 
-use borrow::Borrow;
-use cmp::max;
-use fmt::{self, Debug};
-use hash::{Hash, BuildHasher};
-use iter::FromIterator;
-#[cfg(rayon_hash_unstable)] use iter::FusedIterator;
-use mem::{self, replace};
-use ops::{Deref, Index};
-#[cfg(rayon_hash_unstable)] use ops::{InPlace, Place, Placer};
-#[cfg(rayon_hash_unstable)] use ptr;
+use std::borrow::Borrow;
+use std::cmp::max;
+use std::fmt::{self, Debug};
+use std::hash::{Hash, BuildHasher};
+use std::iter::FromIterator;
+#[cfg(rayon_hash_unstable)] use std::iter::FusedIterator;
+use std::mem::{self, replace};
+use std::ops::{Deref, Index};
+#[cfg(rayon_hash_unstable)] use std::ops::{InPlace, Place, Placer};
+#[cfg(rayon_hash_unstable)] use std::ptr;
 
 pub use std::collections::hash_map::{DefaultHasher, RandomState};
 

--- a/src/std_hash/mod.rs
+++ b/src/std_hash/mod.rs
@@ -10,7 +10,6 @@
 
 //! Unordered containers, implemented as hash-tables
 
-mod bench;
 mod table;
 pub mod map;
 pub mod set;

--- a/src/std_hash/set.rs
+++ b/src/std_hash/set.rs
@@ -8,13 +8,13 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use borrow::Borrow;
-use fmt;
-use hash::{Hash, BuildHasher};
-use iter::{Chain, FromIterator};
+use std::borrow::Borrow;
+use std::fmt;
+use std::hash::{Hash, BuildHasher};
+use std::iter::{Chain, FromIterator};
 #[cfg(rayon_hash_unstable)]
-use iter::FusedIterator;
-use ops::{BitOr, BitAnd, BitXor, Sub};
+use std::iter::FusedIterator;
+use std::ops::{BitOr, BitAnd, BitXor, Sub};
 
 use super::Recover;
 use super::map::{self, HashMap, Keys, RandomState};
@@ -1667,7 +1667,7 @@ mod test_set {
 
     #[test]
     fn test_replace() {
-        use hash;
+        use std::hash;
 
         #[derive(Debug)]
         struct Foo(&'static str, i32);

--- a/src/std_hash/table.rs
+++ b/src/std_hash/table.rs
@@ -17,7 +17,8 @@ use std::marker;
 use std::mem::{align_of, size_of, needs_drop};
 use std::mem;
 use std::ops::{Deref, DerefMut};
-use std::ptr::{self, Unique, Shared};
+use std::ptr;
+use ptr::{Unique, Shared};
 
 use self::BucketState::*;
 

--- a/src/std_hash/table.rs
+++ b/src/std_hash/table.rs
@@ -11,13 +11,13 @@
 // use alloc::heap::{Heap, Alloc, Layout};
 use heap;
 
-use cmp;
-use hash::{BuildHasher, Hash, Hasher};
-use marker;
-use mem::{align_of, size_of, needs_drop};
-use mem;
-use ops::{Deref, DerefMut};
-use ptr::{self, Unique, Shared};
+use std::cmp;
+use std::hash::{BuildHasher, Hash, Hasher};
+use std::marker;
+use std::mem::{align_of, size_of, needs_drop};
+use std::mem;
+use std::ops::{Deref, DerefMut};
+use std::ptr::{self, Unique, Shared};
 
 use self::BucketState::*;
 


### PR DESCRIPTION
This copies core's `Unique`, `Shared`, and `NonZero`, pruned of functionality we don't use here.  With that and a few minor tweaks, we no longer need to require nightly Rust!

Fixes #4.