### PR TITLE
Implement parallel collect for HashMap

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,4 +15,5 @@ num_cpus = "1.2"
 rayon = "0.9"
 
 [dev-dependencies]
+fnv = "1.0.6"
 rand = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ license = "Apache-2.0/MIT"
 readme = "README.md"
 
 [dependencies]
+num_cpus = "1.2"
 rayon = "0.9"
 
 [dev-dependencies]

--- a/benches/set_sum.rs
+++ b/benches/set_sum.rs
@@ -1,9 +1,10 @@
 #![feature(test)]
 
-extern crate test;
+extern crate fnv;
 extern crate rand;
 extern crate rayon;
 extern crate rayon_hash;
+extern crate test;
 
 use rand::{Rng, SeedableRng, XorShiftRng};
 use std::collections::{HashMap as StdHashMap, HashSet as StdHashSet};
@@ -11,6 +12,7 @@ use rayon_hash::{HashMap as RayonHashMap, HashSet as RayonHashSet};
 use std::iter::FromIterator;
 use rayon::prelude::*;
 use test::Bencher;
+use fnv::FnvBuildHasher;
 
 
 fn default_set<C: FromIterator<u32>>(n: usize) -> C {
@@ -43,7 +45,7 @@ macro_rules! bench_collect {
         #[bench]
         fn $id(b: &mut Bencher) {
             b.iter(|| {
-                let set: $ty = (0..1<<20).$iter().map(|x| (x >> 1, ())).collect();
+                let set: $ty = (0u32 .. 1<<20).$iter().map(|x| (x >> 1, ())).collect();
                 assert_eq!(1<<19, set.len());
             })
         }
@@ -54,3 +56,6 @@ bench_collect!{std_collect_serial, StdHashMap<_, _>, into_iter}
 bench_collect!{std_collect_parallel, StdHashMap<_, _>, into_par_iter}
 bench_collect!{rayon_collect_serial, RayonHashMap<_, _>, into_iter}
 bench_collect!{rayon_collect_parallel, RayonHashMap<_, _>, into_par_iter}
+
+bench_collect!{rayon_collect_fnv, RayonHashMap<_, _, FnvBuildHasher>, into_iter}
+bench_collect!{std_collect_fnv, StdHashMap<_, _, FnvBuildHasher>, into_iter}

--- a/benches/set_sum.rs
+++ b/benches/set_sum.rs
@@ -6,8 +6,8 @@ extern crate rayon;
 extern crate rayon_hash;
 
 use rand::{Rng, SeedableRng, XorShiftRng};
-use std::collections::HashSet as StdHashSet;
-use rayon_hash::HashSet as RayonHashSet;
+use std::collections::{HashMap as StdHashMap, HashSet as StdHashSet};
+use rayon_hash::{HashMap as RayonHashMap, HashSet as RayonHashSet};
 use std::iter::FromIterator;
 use rayon::prelude::*;
 use test::Bencher;
@@ -37,3 +37,20 @@ bench_set_sum!{std_set_sum_serial, StdHashSet<_>, iter}
 bench_set_sum!{std_set_sum_parallel, StdHashSet<_>, par_iter}
 bench_set_sum!{rayon_set_sum_serial, RayonHashSet<_>, iter}
 bench_set_sum!{rayon_set_sum_parallel, RayonHashSet<_>, par_iter}
+
+macro_rules! bench_collect {
+    ($id:ident, $ty:ty, $iter:ident) => {
+        #[bench]
+        fn $id(b: &mut Bencher) {
+            b.iter(|| {
+                let set: $ty = (0..1<<20).$iter().map(|x| (x >> 1, ())).collect();
+                assert_eq!(1<<19, set.len());
+            })
+        }
+    }
+}
+
+bench_collect!{std_collect_serial, StdHashMap<_, _>, into_iter}
+bench_collect!{std_collect_parallel, StdHashMap<_, _>, into_par_iter}
+bench_collect!{rayon_collect_serial, RayonHashMap<_, _>, into_iter}
+bench_collect!{rayon_collect_parallel, RayonHashMap<_, _>, into_par_iter}

--- a/src/std_hash/map.rs
+++ b/src/std_hash/map.rs
@@ -572,7 +572,7 @@ impl<K, V, S> HashMap<K, V, S>
 
     // The caller should ensure that invariants by Robin Hood Hashing hold
     // and that there's space in the underlying table.
-    fn insert_hashed_ordered(&mut self, hash: SafeHash, k: K, v: V) {
+    fn _insert_hashed_ordered(&mut self, hash: SafeHash, k: K, v: V) {
         let mut buckets = Bucket::new(&mut self.table, hash);
         let start_index = buckets.index();
 
@@ -808,7 +808,7 @@ impl<K, V, S> HashMap<K, V, S>
                 Full(bucket) => {
                     let h = bucket.hash();
                     let (b, k, v) = bucket.take();
-                    self.insert_hashed_ordered(h, k, v);
+                    self.insert_hashed_nocheck(h, k, v);
                     if b.table().size() == 0 {
                         break;
                     }

--- a/src/std_hash/table.rs
+++ b/src/std_hash/table.rs
@@ -124,7 +124,7 @@ impl TaggedHashUintPtr {
 pub struct RawTable<K, V> {
     capacity_mask: usize,
     capacity_shift: u32,
-    size: usize,
+    pub size: usize,
     hashes: TaggedHashUintPtr,
 
     // Because K/V do not appear directly in any of the types in the struct,
@@ -359,6 +359,13 @@ impl<K, V, M: Deref<Target = RawTable<K, V>>> Bucket<K, V, M> {
         let ib_index = (ib_index >> table.capacity_shift) & table.capacity_mask;
         Bucket {
             raw: table.raw_bucket_at(ib_index),
+            table,
+        }
+    }
+
+    pub fn at_offset(table: M, offset: usize) -> Bucket<K, V, M> {
+        Bucket {
+            raw: table.raw_bucket_at(offset),
             table,
         }
     }


### PR DESCRIPTION
    test rayon_collect_parallel ... bench:  28,819,674 ns/iter (+/- 1,225,005)
    test rayon_collect_serial   ... bench:  57,375,202 ns/iter (+/- 1,833,072)
    test rayon_set_sum_parallel ... bench:   1,202,368 ns/iter (+/- 70,364)
    test rayon_set_sum_serial   ... bench:   7,130,543 ns/iter (+/- 165,480)
    test std_collect_parallel   ... bench:  75,311,224 ns/iter (+/- 22,114,519)
    test std_collect_serial     ... bench:  61,104,321 ns/iter (+/- 5,774,424)
    test std_set_sum_parallel   ... bench:  10,787,688 ns/iter (+/- 668,539)
    test std_set_sum_serial     ... bench:   9,239,331 ns/iter (+/- 284,888)

Surprisingly, serial collect and serial set_sum both become notably faster, presumably just from the indexing shift in the first commit. No idea why that would give different results.