### PR TITLE
Refactor parallel modules, and update to Rayon 1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ matrix:
   include:
     #- rust: 1.25.0
     #- rust: stable
-    #- rust: beta
+    - rust: beta
     - rust: nightly
 
     - rust: nightly

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ license = "Apache-2.0/MIT"
 readme = "README.md"
 
 [dependencies]
-rayon = "0.9"
+rayon = "1.0"
 
 [dev-dependencies]
 rand = "0.4"

--- a/map.rs
+++ b/map.rs
@@ -564,7 +564,7 @@ impl<K, V, S> HashMap<K, V, S>
         where K: Borrow<Q>,
               Q: Eq + Hash
     {
-        if !self.is_empty() {
+        if self.is_empty() {
             return None;
         }
 

--- a/map.rs
+++ b/map.rs
@@ -1290,10 +1290,6 @@ impl<K, V, S> HashMap<K, V, S>
         where K: Borrow<Q>,
               Q: Hash + Eq
     {
-        if self.table.size() == 0 {
-            return None;
-        }
-
         self.search_mut(k)
             .map(|bucket| {
                 let (k, v, _) = pop_internal(bucket);

--- a/map.rs
+++ b/map.rs
@@ -1031,7 +1031,9 @@ impl<K, V, S> HashMap<K, V, S>
     pub fn entry(&mut self, key: K) -> Entry<K, V> {
         // Gotta resize now.
         self.reserve(1);
-        self.search_mut(&key).into_entry(key).expect("unreachable")
+        let hash = self.make_hash(&key);
+        search_hashed(&mut self.table, hash, |q| q.eq(&key))
+            .into_entry(key).expect("unreachable")
     }
 
     /// Returns the number of elements in the map.

--- a/map.rs
+++ b/map.rs
@@ -1039,9 +1039,7 @@ impl<K, V, S> HashMap<K, V, S>
     pub fn entry(&mut self, key: K) -> Entry<K, V> {
         // Gotta resize now.
         self.reserve(1);
-        let hash = self.make_hash(&key);
-        search_hashed(&mut self.table, hash, |q| q.eq(&key))
-            .into_entry(key).expect("unreachable")
+        self.search_mut(&key).into_entry(key).expect("unreachable")
     }
 
     /// Returns the number of elements in the map.

--- a/map.rs
+++ b/map.rs
@@ -417,7 +417,7 @@ fn search_hashed<K, V, M, F>(table: M, hash: SafeHash, is_match: F) -> InternalE
 
 /// Search for a pre-hashed key when the hash map is known to be non-empty.
 #[inline]
-fn search_hashed_nonempty<K, V, M, F>(table: M, hash: SafeHash, is_match: F)
+fn search_hashed_nonempty<K, V, M, F>(table: M, hash: SafeHash, mut is_match: F)
     -> InternalEntry<K, V, M>
     where M: Deref<Target = RawTable<K, V>>,
           F: FnMut(&K) -> bool

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,7 @@ pub use self::hash_map::HashMap;
 // #[stable(feature = "rust1", since = "1.0.0")]
 pub use self::hash_set::HashSet;
 
+mod par;
 mod std_hash;
 
 // #[stable(feature = "rust1", since = "1.0.0")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,4 +35,5 @@ pub mod hash_set {
     //! A hash set implemented as a `HashMap` where the value is `()`.
     // #[stable(feature = "rust1", since = "1.0.0")]
     pub use super::std_hash::set::*;
+    pub use super::par::set::*;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,6 +28,7 @@ pub mod hash_map {
     //! A hash map implemented with linear probing and Robin Hood bucket stealing.
     // #[stable(feature = "rust1", since = "1.0.0")]
     pub use super::std_hash::map::*;
+    pub use super::par::map::*;
 }
 
 // #[stable(feature = "rust1", since = "1.0.0")]

--- a/src/par/map.rs
+++ b/src/par/map.rs
@@ -119,14 +119,7 @@ fn extend<K, V, S, I>(map: &mut HashMap<K, V, S>, par_iter: I)
           I: IntoParallelIterator,
           HashMap<K, V, S>: Extend<I::Item>
 {
-    use std::collections::LinkedList;
-
-    let list: LinkedList<_> = par_iter.into_par_iter()
-        .fold(Vec::new, |mut vec, elem| {
-            vec.push(elem);
-            vec
-        })
-        .collect();
+    let list = ::par::collect(par_iter);
 
     map.reserve(list.iter().map(Vec::len).sum());
     for vec in list {

--- a/src/par/map.rs
+++ b/src/par/map.rs
@@ -1,9 +1,10 @@
 /// Rayon extensions to `HashMap`
 
 use rayon::iter::{ParallelIterator, IntoParallelIterator, FromParallelIterator, ParallelExtend};
+use std::hash::{Hash, BuildHasher};
 
-use super::{Hash, HashMap, BuildHasher};
-use super::super::table;
+use std_hash::table;
+use HashMap;
 
 pub use self::table::{ParIntoIter, ParIter, ParIterMut};
 pub use self::table::{ParKeys, ParValues, ParValuesMut};
@@ -119,7 +120,7 @@ fn extend<K, V, S, I>(map: &mut HashMap<K, V, S>, par_iter: I)
           I: IntoParallelIterator,
           HashMap<K, V, S>: Extend<I::Item>
 {
-    let (list, len) = ::par::collect(par_iter);
+    let (list, len) = super::collect(par_iter);
 
     // Keys may be already present or show multiple times in the iterator.
     // Reserve the entire length if the map is empty.

--- a/src/par/map.rs
+++ b/src/par/map.rs
@@ -3,7 +3,7 @@
 use rayon::iter::{ParallelIterator, IntoParallelIterator, FromParallelIterator, ParallelExtend};
 use std::hash::{Hash, BuildHasher};
 
-use std_hash::table;
+use super::table;
 use HashMap;
 
 pub use self::table::{ParIntoIter, ParIter, ParIterMut};

--- a/src/par/mod.rs
+++ b/src/par/mod.rs
@@ -2,8 +2,8 @@ use rayon::prelude::*;
 use std::collections::LinkedList;
 
 /// Helper for collecting parallel iterators to an intermediary
-pub(crate) fn collect<I: IntoParallelIterator>(iter: I) -> LinkedList<Vec<I::Item>> {
-    iter.into_par_iter()
+pub(crate) fn collect<I: IntoParallelIterator>(iter: I) -> (LinkedList<Vec<I::Item>>, usize) {
+    let list = iter.into_par_iter()
         .fold(Vec::new, |mut vec, elem| {
             vec.push(elem);
             vec
@@ -16,5 +16,8 @@ pub(crate) fn collect<I: IntoParallelIterator>(iter: I) -> LinkedList<Vec<I::Ite
         .reduce(LinkedList::new, |mut list1, mut list2| {
             list1.append(&mut list2);
             list1
-        })
+        });
+
+    let len = list.iter().map(Vec::len).sum();
+    (list, len)
 }

--- a/src/par/mod.rs
+++ b/src/par/mod.rs
@@ -3,6 +3,7 @@ use std::collections::LinkedList;
 
 pub mod map;
 pub mod set;
+mod table;
 
 /// Helper for collecting parallel iterators to an intermediary
 fn collect<I: IntoParallelIterator>(iter: I) -> (LinkedList<Vec<I::Item>>, usize) {

--- a/src/par/mod.rs
+++ b/src/par/mod.rs
@@ -1,1 +1,20 @@
-mod table;
+use rayon::prelude::*;
+use std::collections::LinkedList;
+
+/// Helper for collecting parallel iterators to an intermediary
+pub(crate) fn collect<I: IntoParallelIterator>(iter: I) -> LinkedList<Vec<I::Item>> {
+    iter.into_par_iter()
+        .fold(Vec::new, |mut vec, elem| {
+            vec.push(elem);
+            vec
+        })
+        .map(|vec| {
+            let mut list = LinkedList::new();
+            list.push_back(vec);
+            list
+        })
+        .reduce(LinkedList::new, |mut list1, mut list2| {
+            list1.append(&mut list2);
+            list1
+        })
+}

--- a/src/par/mod.rs
+++ b/src/par/mod.rs
@@ -1,6 +1,8 @@
 use rayon::prelude::*;
 use std::collections::LinkedList;
 
+pub mod set;
+
 /// Helper for collecting parallel iterators to an intermediary
 pub(crate) fn collect<I: IntoParallelIterator>(iter: I) -> (LinkedList<Vec<I::Item>>, usize) {
     let list = iter.into_par_iter()

--- a/src/par/mod.rs
+++ b/src/par/mod.rs
@@ -1,10 +1,11 @@
 use rayon::prelude::*;
 use std::collections::LinkedList;
 
+pub mod map;
 pub mod set;
 
 /// Helper for collecting parallel iterators to an intermediary
-pub(crate) fn collect<I: IntoParallelIterator>(iter: I) -> (LinkedList<Vec<I::Item>>, usize) {
+fn collect<I: IntoParallelIterator>(iter: I) -> (LinkedList<Vec<I::Item>>, usize) {
     let list = iter.into_par_iter()
         .fold(Vec::new, |mut vec, elem| {
             vec.push(elem);

--- a/src/par/set.rs
+++ b/src/par/set.rs
@@ -4,7 +4,7 @@ use rayon::iter::{ParallelIterator, IntoParallelIterator, FromParallelIterator, 
 use rayon::iter::plumbing::UnindexedConsumer;
 use std::hash::{Hash, BuildHasher};
 
-use std_hash::map;
+use par::map;
 use HashSet;
 
 

--- a/src/par/set.rs
+++ b/src/par/set.rs
@@ -152,14 +152,7 @@ fn extend<T, S, I>(set: &mut HashSet<T, S>, par_iter: I)
           I: IntoParallelIterator,
           HashSet<T, S>: Extend<I::Item>
 {
-    use std::collections::LinkedList;
-
-    let list: LinkedList<_> = par_iter.into_par_iter()
-        .fold(Vec::new, |mut vec, elem| {
-            vec.push(elem);
-            vec
-        })
-        .collect();
+    let list = ::par::collect(par_iter);
 
     set.reserve(list.iter().map(Vec::len).sum());
     for vec in list {

--- a/src/par/set.rs
+++ b/src/par/set.rs
@@ -2,8 +2,10 @@
 
 use rayon::iter::{ParallelIterator, IntoParallelIterator, FromParallelIterator, ParallelExtend};
 use rayon::iter::plumbing::UnindexedConsumer;
+use std::hash::{Hash, BuildHasher};
 
-use super::{Hash, HashSet, BuildHasher, map};
+use std_hash::map;
+use HashSet;
 
 
 pub struct ParIntoIter<T: Send> {
@@ -152,7 +154,7 @@ fn extend<T, S, I>(set: &mut HashSet<T, S>, par_iter: I)
           I: IntoParallelIterator,
           HashSet<T, S>: Extend<I::Item>
 {
-    let (list, len) = ::par::collect(par_iter);
+    let (list, len) = super::collect(par_iter);
 
     // Values may be already present or show multiple times in the iterator.
     // Reserve the entire length if the set is empty.

--- a/src/par/set.rs
+++ b/src/par/set.rs
@@ -4,7 +4,7 @@ use rayon::iter::{ParallelIterator, IntoParallelIterator, FromParallelIterator, 
 use rayon::iter::plumbing::UnindexedConsumer;
 use std::hash::{Hash, BuildHasher};
 
-use par::map;
+use super::map;
 use HashSet;
 
 

--- a/src/par/table.rs
+++ b/src/par/table.rs
@@ -26,11 +26,11 @@ impl<'a, K, V> SplitBuckets<'a, K, V> {
 
     fn split<P: From<Self>>(&self) -> (P, Option<P>) {
         let mut left = SplitBuckets { ..*self };
-        let len = left.end - left.bucket.idx;
+        let len = left.end - left.bucket.index();
         if len > 1 {
             let mut right = SplitBuckets { ..left };
-            right.bucket.idx += len / 2;
-            left.end = right.bucket.idx;
+            right.bucket.index_add(len / 2);
+            left.end = right.bucket.index();
             (P::from(left), Some(P::from(right)))
         } else {
             (P::from(left), None)
@@ -42,9 +42,9 @@ impl<'a, K, V> Iterator for SplitBuckets<'a, K, V> {
     type Item = RawBucket<K, V>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        while self.bucket.idx < self.end {
+        while self.bucket.index() < self.end {
             let item = self.bucket;
-            self.bucket.idx += 1;
+            self.bucket.index_add(1);
 
             unsafe {
                 if *item.hash() != EMPTY_BUCKET {
@@ -372,7 +372,7 @@ impl<K: Send, V: Send> ParallelIterator for ParIntoIter<K, V> {
     {
         // Pre-set the map size to zero, indicating all items drained.
         let mut table = self.table;
-        table.size = 0;
+        unsafe { table.set_size(0); }
 
         let buckets = SplitBuckets::new(&table);
         let producer = ParIntoIterProducer::from(buckets);

--- a/src/std_hash/map.rs
+++ b/src/std_hash/map.rs
@@ -27,12 +27,6 @@ pub use std::collections::hash_map::{DefaultHasher, RandomState};
 use super::table::{self, Bucket, EmptyBucket, FullBucket, FullBucketMut, RawTable, SafeHash};
 use super::table::BucketState::{Empty, Full};
 
-#[path="../par/map.rs"]
-pub mod par;
-
-pub use self::par::*;
-
-
 const MIN_NONZERO_RAW_CAPACITY: usize = 32;     // must be a power of two
 
 /// The default behavior of HashMap implements a maximum load factor of 90.9%.
@@ -399,7 +393,7 @@ pub struct HashMap<K, V, S = RandomState> {
     // All hashes are keyed on these values, to prevent hash collision attacks.
     hash_builder: S,
 
-    table: RawTable<K, V>,
+    pub(crate) table: RawTable<K, V>,
 
     resize_policy: DefaultResizePolicy,
 }

--- a/src/std_hash/mod.rs
+++ b/src/std_hash/mod.rs
@@ -10,7 +10,7 @@
 
 //! Unordered containers, implemented as hash-tables
 
-mod table;
+pub(crate) mod table;
 pub mod map;
 pub mod set;
 

--- a/src/std_hash/set.rs
+++ b/src/std_hash/set.rs
@@ -19,12 +19,6 @@ use std::ops::{BitOr, BitAnd, BitXor, Sub};
 use super::Recover;
 use super::map::{self, HashMap, Keys, RandomState};
 
-#[path="../par/set.rs"]
-pub mod par;
-
-pub use self::par::*;
-
-
 // Future Optimization (FIXME!)
 // =============================
 //
@@ -127,7 +121,7 @@ pub use self::par::*;
 #[derive(Clone)]
 // #[stable(feature = "rust1", since = "1.0.0")]
 pub struct HashSet<T, S = RandomState> {
-    map: HashMap<T, (), S>,
+    pub(crate) map: HashMap<T, (), S>,
 }
 
 impl<T: Hash + Eq> HashSet<T, RandomState> {

--- a/src/std_hash/table.rs
+++ b/src/std_hash/table.rs
@@ -33,7 +33,7 @@ use self::BucketState::*;
 /// usize::MAX / size_of(usize) buckets.)
 type HashUint = usize;
 
-pub(crate) const EMPTY_BUCKET: HashUint = 0;
+const EMPTY_BUCKET: HashUint = 0;
 const EMPTY: usize = 1;
 
 /// Special `Unique<HashUint>` that uses the lower bit of the pointer
@@ -235,7 +235,7 @@ fn can_alias_safehash_as_hash() {
 // RawBucket methods are unsafe as it's possible to
 // make a RawBucket point to invalid memory using safe code.
 impl<K, V> RawBucket<K, V> {
-    pub(crate) unsafe fn hash(&self) -> *mut HashUint {
+    unsafe fn hash(&self) -> *mut HashUint {
         self.hash_start.offset(self.idx as isize)
     }
     pub(crate) unsafe fn pair(&self) -> *mut (K, V) {
@@ -249,6 +249,12 @@ impl<K, V> RawBucket<K, V> {
     }
     pub(crate) fn index_add(&mut self, offset: usize) {
         self.idx += offset;
+    }
+    pub(crate) unsafe fn is_empty(&self) -> bool {
+        *self.hash() == EMPTY_BUCKET
+    }
+    pub(crate) unsafe fn set_empty(&self) {
+        *self.hash() = EMPTY_BUCKET;
     }
 }
 


### PR DESCRIPTION
The `par` modules are now more properly separated at the top level, rather than being nested in the `std_hash` modules.  We still need to access some internals to make things work, but this is now done with `pub(crate)` methods to be more explicit about it.

Also, this updates to rayon 1.0, and improves the `ParallelExtend` strategy somewhat like rayon now does.